### PR TITLE
Provide script for NXRM2 Fix #2

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -12,14 +12,15 @@ This would be a match.
 ## Requirements
 * Python3
 * NXRM3 OSS or PRO
+* NXRM2 OSS ot PRO
 
 ## Instructions
 
-### Step 1: Customise values in repo-diff.py
+### Step 1: Customise values in repo-diff.py (NXRM3) or repo-deff-nxrm2.py (NXRM2)
 You'll need to modify the script to include 
-1. Auth creds or tokens from your NXRM3.
-1. URL to your Nexus
-1. Repositories to compare in REPOS. e.g. to compare ruby and npm hosted to their proxies
+1. Auth creds or tokens from your NXRM. (`USER` and `TOKEN`)
+1. URL to your Nexus (`REPO_HOSTNAME`)
+1. Repositories to compare in `REPOS`. e.g. to compare ruby and npm hosted to their proxies
 
 ```python
 REPOS = {

--- a/README.MD
+++ b/README.MD
@@ -16,7 +16,7 @@ This would be a match.
 
 ## Instructions
 
-### Step 1: Customise values in repo-diff.py (NXRM3) or repo-deff-nxrm2.py (NXRM2)
+### Step 1: Customise values in repo-diff.py (NXRM3) or repo-diff-nxrm2.py (NXRM2)
 You'll need to modify the script to include 
 1. Auth creds or tokens from your NXRM. (`USER` and `TOKEN`)
 1. URL to your Nexus (`REPO_HOSTNAME`)

--- a/repo-diff-nxrm2.py
+++ b/repo-diff-nxrm2.py
@@ -1,0 +1,53 @@
+import logging
+import requests
+import numpy as np
+from bs4 import BeautifulSoup
+
+REPO_HOSTNAME = "http://localhost:8082"
+
+# Uncomment the correct REPO_PATH for your version or NXRM
+REPO_PATH = "nexus/content/repositories"  # REPO 2
+
+# You can use NXRM2 version of the script on NXRM3 by uncommenting the following REPO_PATH
+# Using the NXRM2 script for NXRM3 is a workaround to issues when searching against extremely large repos
+# REPO_PATH = "service/rest/repository/browse"  # REPO 3
+
+USER = 'username'
+TOKEN = 'password'
+
+REPOS = {
+    # hosted: proxy
+    # "python-hosted": "pypi-proxy",
+    "npm-hosted": "npm-proxy"
+}
+
+log = logging.getLogger('repo-diff-html')
+
+
+def main():
+    logging.basicConfig(filename='./repo-diff-html.log', level=logging.INFO)
+    for hosted, proxy in REPOS.items():
+        print("-------------------")
+        print("Hosted: {0} | Proxy: {1}".format(hosted, proxy))
+        hosted_list = get_page(hosted)
+        proxy_list = get_page(proxy)
+
+        print(np.intersect1d(proxy_list, hosted_list))
+
+
+def get_page(repo):
+    component_list = []
+    page = requests.get("{0}/{1}/{2}/".format(REPO_HOSTNAME, REPO_PATH, repo), auth=(USER, TOKEN))
+
+    if page.ok:
+        soup = BeautifulSoup(page.text, 'html.parser')
+        for component in soup.find_all('a'):
+            if component.text == "Parent Directory":
+                continue
+            component_list.append(component.text)
+
+        return component_list
+
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ idna==2.10
 numpy==1.20.1
 requests==2.25.1
 urllib3==1.26.3
+soupsieve==2.2
+beautifulsoup4==4.9.3


### PR DESCRIPTION
Provide script for NXRM2.  The NXRM2 script can also be used as a workaround for extremely large NXRM3 repo searches. 